### PR TITLE
WIP: Explicit late preloading

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -573,7 +573,7 @@ module ActiveRecord
       end
 
       def has_loaded_parent?
-        @parent.present? and @parent.loaded?
+        @parent and @parent.loaded?
       end
 
       def preload_associations

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -132,7 +132,7 @@ module ActiveRecord
     #   # "users"."id"
     def eager_load(*args)
       check_if_method_has_arguments!(:eager_load, args)
-      spawn.eager_load!(*args)
+      spawn_without_parent.eager_load!(*args)
     end
 
     def eager_load!(*args) # :nodoc:
@@ -166,7 +166,7 @@ module ActiveRecord
     #   # Query now knows the string references posts, so adds a JOIN
     def references(*table_names)
       check_if_method_has_arguments!(:references, table_names)
-      spawn.references!(*table_names)
+      spawn_without_parent.references!(*table_names)
     end
 
     def references!(*table_names) # :nodoc:
@@ -227,7 +227,7 @@ module ActiveRecord
       end
 
       raise ArgumentError, "Call `select' with at least one field" if fields.empty?
-      spawn._select!(*fields)
+      spawn_without_parent._select!(*fields)
     end
 
     def _select!(*fields) # :nodoc:
@@ -261,7 +261,7 @@ module ActiveRecord
     #   # => [#<User id: 1, first_name: "Bill">, #<User id: 2, first_name: "Earl">, #<User id: 3, first_name: "Beto">]
     def group(*args)
       check_if_method_has_arguments!(:group, args)
-      spawn.group!(*args)
+      spawn_without_parent.group!(*args)
     end
 
     def group!(*args) # :nodoc:
@@ -292,7 +292,7 @@ module ActiveRecord
     #   # SELECT "users".* FROM "users" ORDER BY name DESC, email
     def order(*args)
       check_if_method_has_arguments!(:order, args)
-      spawn.order!(*args)
+      spawn_without_parent.order!(*args)
     end
 
     # Same as #order but operates on relation in-place instead of copying.
@@ -314,7 +314,7 @@ module ActiveRecord
     # generates a query with 'ORDER BY id ASC, name ASC'.
     def reorder(*args)
       check_if_method_has_arguments!(:reorder, args)
-      spawn.reorder!(*args)
+      spawn_without_parent.reorder!(*args)
     end
 
     # Same as #reorder but operates on relation in-place instead of copying.
@@ -365,7 +365,7 @@ module ActiveRecord
     #
     def unscope(*args)
       check_if_method_has_arguments!(:unscope, args)
-      spawn.unscope!(*args)
+      spawn_without_parent.unscope!(*args)
     end
 
     def unscope!(*args) # :nodoc:
@@ -427,7 +427,7 @@ module ActiveRecord
     #   # SELECT "users".* FROM "users" LEFT JOIN bookmarks ON bookmarks.bookmarkable_type = 'Post' AND bookmarks.user_id = users.id
     def joins(*args)
       check_if_method_has_arguments!(:joins, args)
-      spawn.joins!(*args)
+      spawn_without_parent.joins!(*args)
     end
 
     def joins!(*args) # :nodoc:
@@ -444,7 +444,7 @@ module ActiveRecord
     #
     def left_outer_joins(*args)
       check_if_method_has_arguments!(__callee__, args)
-      spawn.left_outer_joins!(*args)
+      spawn_without_parent.left_outer_joins!(*args)
     end
     alias :left_joins :left_outer_joins
 
@@ -576,11 +576,11 @@ module ActiveRecord
     # the current relation.
     def where(opts = :chain, *rest)
       if :chain == opts
-        WhereChain.new(spawn)
+        WhereChain.new(spawn_without_parent)
       elsif opts.blank?
         self
       else
-        spawn.where!(opts, *rest)
+        spawn_without_parent.where!(opts, *rest)
       end
     end
 
@@ -623,7 +623,7 @@ module ActiveRecord
         raise ArgumentError, "You have passed #{other.class.name} object to #or. Pass an ActiveRecord::Relation object instead."
       end
 
-      spawn.or!(other)
+      spawn_without_parent.or!(other)
     end
 
     def or!(other) # :nodoc:
@@ -662,7 +662,7 @@ module ActiveRecord
     #
     #   User.limit(10).limit(20) # generated SQL has 'LIMIT 20'
     def limit(value)
-      spawn.limit!(value)
+      spawn_without_parent.limit!(value)
     end
 
     def limit!(value) # :nodoc:
@@ -689,7 +689,7 @@ module ActiveRecord
     # Specifies locking settings (default to +true+). For more information
     # on locking, please see ActiveRecord::Locking.
     def lock(locks = true)
-      spawn.lock!(locks)
+      spawn_without_parent.lock!(locks)
     end
 
     def lock!(locks = true) # :nodoc:
@@ -732,7 +732,7 @@ module ActiveRecord
     #   end
     #
     def none
-      spawn.none!
+      spawn_without_parent.none!
     end
 
     def none! # :nodoc:
@@ -746,7 +746,7 @@ module ActiveRecord
     #   users.first.save
     #   => ActiveRecord::ReadOnlyRecord: User is marked as readonly
     def readonly(value = true)
-      spawn.readonly!(value)
+      spawn_without_parent.readonly!(value)
     end
 
     def readonly!(value = true) # :nodoc:
@@ -796,7 +796,7 @@ module ActiveRecord
     #   # SELECT a.title FROM (SELECT * FROM topics WHERE approved = 't') a
     #
     def from(value, subquery_name = nil)
-      spawn.from!(value, subquery_name)
+      spawn_without_parent.from!(value, subquery_name)
     end
 
     def from!(value, subquery_name = nil) # :nodoc:
@@ -815,7 +815,7 @@ module ActiveRecord
     #   User.select(:name).distinct.distinct(false)
     #   # You can also remove the uniqueness
     def distinct(value = true)
-      spawn.distinct!(value)
+      spawn_without_parent.distinct!(value)
     end
 
     # Like #distinct, but modifies relation in place.
@@ -862,7 +862,7 @@ module ActiveRecord
     #   end
     def extending(*modules, &block)
       if modules.any? || block
-        spawn.extending!(*modules, &block)
+        spawn_without_parent.extending!(*modules, &block)
       else
         self
       end
@@ -882,7 +882,7 @@ module ActiveRecord
     #
     #   User.order('name ASC').reverse_order # generated SQL has 'ORDER BY name DESC'
     def reverse_order
-      spawn.reverse_order!
+      spawn_without_parent.reverse_order!
     end
 
     def reverse_order! # :nodoc:

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -113,7 +113,7 @@ module ActiveRecord
     # the actual table name.
     def includes(*args)
       check_if_method_has_arguments!(:includes, args)
-      spawn.includes!(*args)
+      spawn_with_parent.includes!(*args)
     end
 
     def includes!(*args) # :nodoc:

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -146,7 +146,7 @@ module ActiveRecord
     #   # SELECT "posts".* FROM "posts" WHERE "posts"."user_id" IN (1, 2, 3)
     def preload(*args)
       check_if_method_has_arguments!(:preload, args)
-      spawn.preload!(*args)
+      spawn_with_parent.preload!(*args)
     end
 
     def preload!(*args) # :nodoc:

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -132,7 +132,7 @@ module ActiveRecord
     #   # "users"."id"
     def eager_load(*args)
       check_if_method_has_arguments!(:eager_load, args)
-      spawn_without_parent.eager_load!(*args)
+      spawn.eager_load!(*args)
     end
 
     def eager_load!(*args) # :nodoc:
@@ -166,7 +166,7 @@ module ActiveRecord
     #   # Query now knows the string references posts, so adds a JOIN
     def references(*table_names)
       check_if_method_has_arguments!(:references, table_names)
-      spawn_without_parent.references!(*table_names)
+      spawn.references!(*table_names)
     end
 
     def references!(*table_names) # :nodoc:
@@ -227,7 +227,7 @@ module ActiveRecord
       end
 
       raise ArgumentError, "Call `select' with at least one field" if fields.empty?
-      spawn_without_parent._select!(*fields)
+      spawn._select!(*fields)
     end
 
     def _select!(*fields) # :nodoc:
@@ -261,7 +261,7 @@ module ActiveRecord
     #   # => [#<User id: 1, first_name: "Bill">, #<User id: 2, first_name: "Earl">, #<User id: 3, first_name: "Beto">]
     def group(*args)
       check_if_method_has_arguments!(:group, args)
-      spawn_without_parent.group!(*args)
+      spawn.group!(*args)
     end
 
     def group!(*args) # :nodoc:
@@ -292,7 +292,7 @@ module ActiveRecord
     #   # SELECT "users".* FROM "users" ORDER BY name DESC, email
     def order(*args)
       check_if_method_has_arguments!(:order, args)
-      spawn_without_parent.order!(*args)
+      spawn.order!(*args)
     end
 
     # Same as #order but operates on relation in-place instead of copying.
@@ -314,7 +314,7 @@ module ActiveRecord
     # generates a query with 'ORDER BY id ASC, name ASC'.
     def reorder(*args)
       check_if_method_has_arguments!(:reorder, args)
-      spawn_without_parent.reorder!(*args)
+      spawn.reorder!(*args)
     end
 
     # Same as #reorder but operates on relation in-place instead of copying.
@@ -365,7 +365,7 @@ module ActiveRecord
     #
     def unscope(*args)
       check_if_method_has_arguments!(:unscope, args)
-      spawn_without_parent.unscope!(*args)
+      spawn.unscope!(*args)
     end
 
     def unscope!(*args) # :nodoc:
@@ -427,7 +427,7 @@ module ActiveRecord
     #   # SELECT "users".* FROM "users" LEFT JOIN bookmarks ON bookmarks.bookmarkable_type = 'Post' AND bookmarks.user_id = users.id
     def joins(*args)
       check_if_method_has_arguments!(:joins, args)
-      spawn_without_parent.joins!(*args)
+      spawn.joins!(*args)
     end
 
     def joins!(*args) # :nodoc:
@@ -444,7 +444,7 @@ module ActiveRecord
     #
     def left_outer_joins(*args)
       check_if_method_has_arguments!(__callee__, args)
-      spawn_without_parent.left_outer_joins!(*args)
+      spawn.left_outer_joins!(*args)
     end
     alias :left_joins :left_outer_joins
 
@@ -576,11 +576,11 @@ module ActiveRecord
     # the current relation.
     def where(opts = :chain, *rest)
       if :chain == opts
-        WhereChain.new(spawn_without_parent)
+        WhereChain.new(spawn)
       elsif opts.blank?
         self
       else
-        spawn_without_parent.where!(opts, *rest)
+        spawn.where!(opts, *rest)
       end
     end
 
@@ -623,7 +623,7 @@ module ActiveRecord
         raise ArgumentError, "You have passed #{other.class.name} object to #or. Pass an ActiveRecord::Relation object instead."
       end
 
-      spawn_without_parent.or!(other)
+      spawn.or!(other)
     end
 
     def or!(other) # :nodoc:
@@ -662,7 +662,7 @@ module ActiveRecord
     #
     #   User.limit(10).limit(20) # generated SQL has 'LIMIT 20'
     def limit(value)
-      spawn_without_parent.limit!(value)
+      spawn.limit!(value)
     end
 
     def limit!(value) # :nodoc:
@@ -689,7 +689,7 @@ module ActiveRecord
     # Specifies locking settings (default to +true+). For more information
     # on locking, please see ActiveRecord::Locking.
     def lock(locks = true)
-      spawn_without_parent.lock!(locks)
+      spawn.lock!(locks)
     end
 
     def lock!(locks = true) # :nodoc:
@@ -732,7 +732,7 @@ module ActiveRecord
     #   end
     #
     def none
-      spawn_without_parent.none!
+      spawn.none!
     end
 
     def none! # :nodoc:
@@ -746,7 +746,7 @@ module ActiveRecord
     #   users.first.save
     #   => ActiveRecord::ReadOnlyRecord: User is marked as readonly
     def readonly(value = true)
-      spawn_without_parent.readonly!(value)
+      spawn.readonly!(value)
     end
 
     def readonly!(value = true) # :nodoc:
@@ -796,7 +796,7 @@ module ActiveRecord
     #   # SELECT a.title FROM (SELECT * FROM topics WHERE approved = 't') a
     #
     def from(value, subquery_name = nil)
-      spawn_without_parent.from!(value, subquery_name)
+      spawn.from!(value, subquery_name)
     end
 
     def from!(value, subquery_name = nil) # :nodoc:
@@ -815,7 +815,7 @@ module ActiveRecord
     #   User.select(:name).distinct.distinct(false)
     #   # You can also remove the uniqueness
     def distinct(value = true)
-      spawn_without_parent.distinct!(value)
+      spawn.distinct!(value)
     end
 
     # Like #distinct, but modifies relation in place.
@@ -862,7 +862,7 @@ module ActiveRecord
     #   end
     def extending(*modules, &block)
       if modules.any? || block
-        spawn_without_parent.extending!(*modules, &block)
+        spawn.extending!(*modules, &block)
       else
         self
       end
@@ -882,7 +882,7 @@ module ActiveRecord
     #
     #   User.order('name ASC').reverse_order # generated SQL has 'ORDER BY name DESC'
     def reverse_order
-      spawn_without_parent.reverse_order!
+      spawn.reverse_order!
     end
 
     def reverse_order! # :nodoc:

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -16,6 +16,11 @@ module ActiveRecord
       clone.tap { |c| c.parent = self }
     end
 
+    def spawn_without_parent
+      parent = self
+      clone.tap { |c| c.parent = nil }
+    end
+
     # Merges in the conditions from <tt>other</tt>, if <tt>other</tt> is an ActiveRecord::Relation.
     # Returns an array representing the intersection of the resulting records with <tt>other</tt>, if <tt>other</tt> is an array.
     #

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -11,6 +11,11 @@ module ActiveRecord
       clone
     end
 
+    def spawn_with_parent
+      parent = self
+      clone.tap { |c| c.parent = self }
+    end
+
     # Merges in the conditions from <tt>other</tt>, if <tt>other</tt> is an ActiveRecord::Relation.
     # Returns an array representing the intersection of the resulting records with <tt>other</tt>, if <tt>other</tt> is an array.
     #

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -8,17 +8,11 @@ module ActiveRecord
   module SpawnMethods
     # This is overridden by Associations::CollectionProxy
     def spawn #:nodoc:
-      clone
+      clone.tap { |c| c.parent = self; c.use_parent_records = false }
     end
 
     def spawn_with_parent
-      parent = self
-      clone.tap { |c| c.parent = self }
-    end
-
-    def spawn_without_parent
-      parent = self
-      clone.tap { |c| c.parent = nil }
+      clone.tap { |c| c.parent = self; c.use_parent_records = true }
     end
 
     # Merges in the conditions from <tt>other</tt>, if <tt>other</tt> is an ActiveRecord::Relation.

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -641,7 +641,14 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
-  def test_loading_with_one_association
+  def test_delayed_preloading
+    assert_queries(2) do
+      posts = Post.all.load
+      posts.preload(:comments).load
+    end
+  end
+
+ def test_loading_with_one_association
     posts = Post.preload(:comments)
     post = posts.find { |p| p.id == 1 }
     assert_equal 2, post.comments.size

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -641,14 +641,28 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
-  def test_delayed_preloading
+  def test_delayed_preload
     assert_queries(2) do
       posts = Post.all.load
-      posts.preload(:comments).load
+      posts.preload(:comments).each { |p| p.comments }
     end
   end
 
- def test_loading_with_one_association
+  def test_delayed_eager_load
+    assert_queries(2) do
+      posts = Post.all.load
+      posts.eager_load(:comments).each { |p| p.comments }
+    end
+  end
+
+  def test_delayed_includes
+    assert_queries(2) do
+      posts = Post.all.load
+      posts.includes(:comments).each { |p| p.comments }
+    end
+  end
+
+  def test_loading_with_one_association
     posts = Post.preload(:comments)
     post = posts.find { |p| p.id == 1 }
     assert_equal 2, post.comments.size

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -648,17 +648,18 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
-  def test_delayed_eager_load
-    assert_queries(2) do
-      posts = Post.all.load
-      posts.eager_load(:comments).each { |p| p.comments }
-    end
-  end
-
   def test_delayed_includes
     assert_queries(2) do
       posts = Post.all.load
       posts.includes(:comments).each { |p| p.comments }
+    end
+  end
+
+  def test_delayed_includes_does_not_use_join
+    assert_queries(2) do
+      posts = Post.all.eager_load(:readers).load
+      posts.includes(:comments).each { |p| p.comments }
+      assert_not_includes posts.includes(:comments).to_sql, "JOIN"
     end
   end
 


### PR DESCRIPTION
First pass at delayed preloading on relations.

### Considerations

- Is there a better way to handle cloning? We want to prevent other classes from calling `spawn_with_parent` or `spawn_without_parent` since they won't have a parent member. Is there a way to define the parent member such that it's not carried through clones? (i.e. Is there a way to avoid needing a `spawn_without_parent`?)
- We don't store which associations we've already preloaded. This means if we have `Foo.preload(:bars).load.includes(:bazs)`, we'll preload :bar again. Associations can only be loaded if records are loaded, so perhaps we could have a method iterate through the raw preload list check `records.first.bars.loaded?` and skip those.